### PR TITLE
Add print support for month calendar view

### DIFF
--- a/src/App/View/Calendar/MonthView.php
+++ b/src/App/View/Calendar/MonthView.php
@@ -11,6 +11,7 @@ use Osec\Exception\BootstrapException;
 use Osec\Exception\TimezoneException;
 use Osec\Http\Request\Request;
 use Osec\Settings\HtmlFactory;
+use Osec\Theme\ThemeLoader;
 use Osec\Twig\TwigExtension;
 
 /**
@@ -82,13 +83,29 @@ class MonthView extends AbstractView
             'pagination_links'         => $pagination_links,
         ];
 
+        // Add the existing OSEC print button to month view when enabled in settings.
+        // OSEC already wires #ai1ec-print-button to its built-in print handler.
+        $after_pagination = '';
+        if ($this->app->settings->get('display_print_button')) {
+            $button_args      = [
+                'text_collapse_all'    => __('Collapse All', 'open-source-event-calendar'),
+                'text_expand_all'      => __('Expand All', 'open-source-event-calendar'),
+                'no_toggle'            => true,
+                'display_print_button' => true,
+            ];
+            $after_pagination = ThemeLoader::factory($this->app)
+                ->get_file('agenda-buttons.twig', $button_args, false)
+                ->get_content();
+        }
+
         // Add navigation if requested.
         $view_args['navigation'] = $this->getNavigation(
             [
                 'display_date_navigation' => $args['display_date_navigation'],
-                'pagination_links' => $pagination_links,
-                'views_dropdown'   => $args['views_dropdown'],
-                'below_toolbar'    => $this->getBelowToolbarHtml($this->get_name(), $view_args),
+                'pagination_links'        => $pagination_links,
+                'views_dropdown'          => $args['views_dropdown'],
+                'after_pagination'        => $after_pagination,
+                'below_toolbar'           => $this->getBelowToolbarHtml($this->get_name(), $view_args),
             ]
         );
 


### PR DESCRIPTION
This PR adds print support to the month calendar view.

Currently, OSEC renders the built-in print button for agenda view, but not for month view. This change adds the existing OSEC print button to MonthView.php when the "Display print icon" setting is enabled.

It also improves the print handler so month view prints cleanly by:

- adding the visible calendar month/year as a print title
- removing popup/popover markup from the print copy
- suppressing printed link URLs
- removing href attributes during the print operation
- adding print cleanup styles for the temporary print DOM

Tested on a live WordPress site using the OSEC month view. The print button appears in month view and produces a clean landscape calendar printout with the month/year title.